### PR TITLE
fix 4 flaky tests by json obj comparison

### DIFF
--- a/src/test/java/dev/akif/exchange/conversion/impl/ConversionControllerTest.java
+++ b/src/test/java/dev/akif/exchange/conversion/impl/ConversionControllerTest.java
@@ -19,6 +19,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import dev.akif.exchange.common.CurrencyPair;
 import dev.akif.exchange.common.Errors;
 import dev.akif.exchange.common.PagedResponse;
@@ -83,7 +85,8 @@ public class ConversionControllerTest {
         MockHttpServletResponse response = perform(conversionRequest("USD", "TRY", 10.0));
 
         assertEquals(201, response.getStatus());
-        assertEquals(expected.toString(), response.getContentAsString());
+        ObjectMapper mapper = new ObjectMapper();
+        assertEquals(mapper.readTree(expected.toString()), mapper.readTree(response.getContentAsString()));
     }
 
     @Test
@@ -109,7 +112,8 @@ public class ConversionControllerTest {
         MockHttpServletResponse response = perform(getRequest(2L));
 
         assertEquals(200, response.getStatus());
-        assertEquals(expected.toString(), response.getContentAsString());
+        ObjectMapper mapper = new ObjectMapper();
+        assertEquals(mapper.readTree(expected.toString()), mapper.readTree(response.getContentAsString()));
     }
 
     @Test
@@ -140,7 +144,8 @@ public class ConversionControllerTest {
         MockHttpServletResponse response = perform(listRequest(null, null, 1, 5, true));
 
         assertEquals(200, response.getStatus());
-        assertEquals(expected.toString(), response.getContentAsString());
+        ObjectMapper mapper = new ObjectMapper();
+        assertEquals(mapper.readTree(expected.toString()), mapper.readTree(response.getContentAsString()));
     }
 
     private MockHttpServletRequestBuilder conversionRequest(String source, String target, double amount) {

--- a/src/test/java/dev/akif/exchange/rate/impl/RateControllerTest.java
+++ b/src/test/java/dev/akif/exchange/rate/impl/RateControllerTest.java
@@ -15,6 +15,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import dev.akif.exchange.common.CurrencyPair;
 import dev.akif.exchange.common.Errors;
 import dev.akif.exchange.provider.TimeProvider;
@@ -80,7 +82,8 @@ public class RateControllerTest {
         MockHttpServletResponse response = perform(ratesRequest("USD", "TRY"));
 
         assertEquals(200, response.getStatus());
-        assertEquals(expected.toString(), response.getContentAsString());
+        ObjectMapper mapper = new ObjectMapper();
+        assertEquals(mapper.readTree(expected.toString()), mapper.readTree(response.getContentAsString()));
     }
 
     private MockHttpServletRequestBuilder ratesRequest(String source, String target) {


### PR DESCRIPTION
### Description

- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [X] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

Fix four flaky tests by using json object comparison instead of raw string comparison.

### Related Test
[dev.akif.exchange.conversion.impl.ConversionControllerTest.creatingANewConversionReturnsCreatedConversion](https://github.com/lxb007981/exchange/blob/d612711036ac76b5eea43ec2d1fa49d649166809/src/test/java/dev/akif/exchange/conversion/impl/ConversionControllerTest.java#L78)

[dev.akif.exchange.conversion.impl.ConversionControllerTest.gettingAConversionReturnsConversion](https://github.com/lxb007981/exchange/blob/d612711036ac76b5eea43ec2d1fa49d649166809/src/test/java/dev/akif/exchange/conversion/impl/ConversionControllerTest.java#L104)

[dev.akif.exchange.conversion.impl.ConversionControllerTest.listingConversionsReturnsConversions](https://github.com/lxb007981/exchange/blob/d612711036ac76b5eea43ec2d1fa49d649166809/src/test/java/dev/akif/exchange/conversion/impl/ConversionControllerTest.java#L130)

[dev.akif.exchange.rate.impl.RateControllerTest.gettingRatesReturnsRates](https://github.com/lxb007981/exchange/blob/d612711036ac76b5eea43ec2d1fa49d649166809/src/test/java/dev/akif/exchange/rate/impl/RateControllerTest.java#L73)

### Root Cause
While the expected string stays the same, when generating `MockHttpServletResponse` and converting it to the actual string, the order of the actual json string's properties is not deterministic. 

### Fix
We build two json objects from the two strings and perform json object comparison, so that the order dependency is eliminated.

### How to reproduce the test
**Java version**: 11.0.20.1

1. Build the module
`./gradlew build -x test`
2. Test without shuffling
`./gradlew --info test --tests=dev.akif.exchange.conversion.impl.ConversionControllerTest.creatingANewConversionReturnsCreatedConversion`
`./gradlew --info test --tests=dev.akif.exchange.conversion.impl.ConversionControllerTest.gettingAConversionReturnsConversion` 
`./gradlew --info test --tests=dev.akif.exchange.conversion.impl.ConversionControllerTest.listingConversionsReturnsConversions`
`./gradlew --info test --tests=dev.akif.exchange.rate.impl.RateControllerTest.gettingRatesReturnsRates`
These four tests passed.

3. Test with shuffling using [NonDex](https://github.com/TestingResearchIllinois/NonDex)
`./gradlew --info nondexTest --tests=dev.akif.exchange.conversion.impl.ConversionControllerTest.creatingANewConversionReturnsCreatedConversion --nondexRuns=5`
`./gradlew --info nondexTest --tests=dev.akif.exchange.conversion.impl.ConversionControllerTest.gettingAConversionReturnsConversion --nondexRuns=5` 
`./gradlew --info nondexTest --tests=dev.akif.exchange.conversion.impl.ConversionControllerTest.listingConversionsReturnsConversions --nondexRuns=5`
`./gradlew --info nondexTest --tests=dev.akif.exchange.rate.impl.RateControllerTest.gettingRatesReturnsRates --nondexRuns=5`
The tests passed with the proposed fix but failed without it.